### PR TITLE
Add missing dot

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Then:
 ```bash
 $ git clone https://github.com/memsharded/qmake_example
 $ cd qmake_example
-$ conan install
+$ conan install .
 $ qmake
 $ make
 $ ./helloworld


### PR DESCRIPTION
README.md example is missing dot in command line `conan install`, which produces error `conan install: error: the following arguments are required: path_or_reference`. 

Add dot to make example working.